### PR TITLE
Make `HOST_URL` for DB app a normal, non-secret config variable

### DIFF
--- a/templates/production/api-deployment.yaml
+++ b/templates/production/api-deployment.yaml
@@ -67,10 +67,7 @@ spec:
           value: "2018-10-23T07:00:00Z"
         # TODO: consider making this not a secret
         - name: HOST_URL
-          valueFrom:
-            secretKeyRef:
-              name: app-secrets
-              key: host_url
+          value: "https://api.monitoring.envirodatagov.org/"
         - name: LANG
           value: en_US.UTF-8
         - name: MAIL_SENDER

--- a/templates/production/import-worker-deployment.yaml
+++ b/templates/production/import-worker-deployment.yaml
@@ -59,10 +59,7 @@ spec:
         - name: DIFFER_DEFAULT
           value: http://diffing:80
         - name: HOST_URL
-          valueFrom:
-            secretKeyRef:
-              name: app-secrets
-              key: host_url
+          value: "https://api.monitoring.envirodatagov.org/"
         - name: LANG
           value: en_US.UTF-8
         - name: MAIL_SENDER

--- a/templates/staging/api-deployment.yaml
+++ b/templates/staging/api-deployment.yaml
@@ -67,10 +67,7 @@ spec:
           value: "2018-10-23T07:00:00Z"
         # TODO: consider making this not a secret
         - name: HOST_URL
-          valueFrom:
-            secretKeyRef:
-              name: app-secrets
-              key: host_url
+          value: "https://api-staging.monitoring.envirodatagov.org/"
         - name: LANG
           value: en_US.UTF-8
         - name: MAIL_SENDER

--- a/templates/staging/import-worker-deployment.yaml
+++ b/templates/staging/import-worker-deployment.yaml
@@ -59,10 +59,7 @@ spec:
         - name: DIFFER_DEFAULT
           value: http://diffing:80
         - name: HOST_URL
-          valueFrom:
-            secretKeyRef:
-              name: app-secrets
-              key: host_url
+          value: "https://api-staging.monitoring.envirodatagov.org/"
         - name: LANG
           value: en_US.UTF-8
         - name: MAIL_SENDER


### PR DESCRIPTION
The `HOST_URL` for web-monitoring-db is definitely not a secret (it’s just the public URL for the service), so this shouldn’t be hidden and abstracted away in a secrets file.

Fixes #2.