### PR TITLE
Update page statuses on a regular schedule

### DIFF
--- a/kubernetes/production/status-update-job.yaml
+++ b/kubernetes/production/status-update-job.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: status-update-job
+  namespace: production
+spec:
+  schedule: "0 10,22 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: db-status-update-job
+            image: envirodgi/db-status-update-job:44edf412ade04beb7f924c3c3ae04f60ce392022
+            imagePullPolicy: Always
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "1024Mi"
+                cpu: "1500m"
+            env:
+            - name: ALLOWED_ARCHIVE_HOSTS
+              value: "https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/ https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3.amazonaws.com/edgi-versionista-archive/"
+            - name: AUTO_ANNOTATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: auto_annotation_user
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws_access_key_id
+            - name: AWS_ARCHIVE_BUCKET
+              value: edgi-wm-archive
+            - name: AWS_REGION
+              value: us-west-2
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws_secret_access_key
+            - name: AWS_WORKING_BUCKET
+              value: edgi-wm-db-internal
+            - name: CACHE_DATE_DIFFER
+              value: "2019-09-22T00:00:00Z"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: database_rds
+            - name: DIFFER_DEFAULT
+              value: http://diffing:80
+            - name: HOST_URL
+              value: "https://api.monitoring.envirodatagov.org/"
+            - name: LANG
+              value: en_US.UTF-8
+            - name: MAIL_SENDER
+              value: website.monitoring@envirodatagov.org
+            - name: MAX_COLLECTION_PAGE_SIZE
+              value: "1000"
+            - name: NEW_RELIC_AGENT_ENABLED
+              value: "false"
+            - name: POSTMARK_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: postmark_api_token
+            - name: RACK_ENV
+              value: production
+            - name: RAILS_ENV
+              value: production
+            - name: RAILS_LOG_TO_STDOUT
+              value: enabled
+            - name: RAILS_SERVE_STATIC_FILES
+              value: enabled
+            - name: REDIS_URL
+              value: redis://redis-master:6379
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: secret_key_base
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sentry_dsn
+            - name: TOKEN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: token_private_key
+            - name: INCREMENTAL_UPDATE
+              value: "1"

--- a/kubernetes/staging/status-update-job.yaml
+++ b/kubernetes/staging/status-update-job.yaml
@@ -1,0 +1,98 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: status-update-job
+  namespace: staging
+spec:
+  schedule: "0 10,22 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: db-status-update-job
+            image: envirodgi/db-status-update-job:44edf412ade04beb7f924c3c3ae04f60ce392022
+            imagePullPolicy: Always
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "1024Mi"
+                cpu: "1500m"
+            env:
+            - name: ALLOWED_ARCHIVE_HOSTS
+              value: "https://edgi-wm-versionista.s3.amazonaws.com/ https://edgi-wm-versionista.s3-us-west-2.amazonaws.com/ https://s3-us-west-2.amazonaws.com/edgi-wm-versionista/ https://edgi-versionista-archive.s3.amazonaws.com/ https://edgi-versionista-archive.s3.amazonaws.com/edgi-versionista-archive/"
+            - name: AUTO_ANNOTATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: auto_annotation_user
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws_access_key_id
+            - name: AWS_ARCHIVE_BUCKET
+              value: edgi-wm-archive-staging
+            - name: AWS_REGION
+              value: us-west-2
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: aws_secret_access_key
+            - name: AWS_WORKING_BUCKET
+              value: edgi-wm-db-internal-staging
+            - name: CACHE_DATE_DIFFER
+              value: "2019-09-22T00:00:00Z"
+            - name: DATABASE_RDS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: database_rds
+            - name: DIFFER_DEFAULT
+              value: http://diffing:80
+            - name: HOST_URL
+              value: "https://api-staging.monitoring.envirodatagov.org/"
+            - name: LANG
+              value: en_US.UTF-8
+            - name: MAIL_SENDER
+              value: website.monitoring@envirodatagov.org
+            - name: MAX_COLLECTION_PAGE_SIZE
+              value: "1000"
+            - name: NEW_RELIC_AGENT_ENABLED
+              value: "false"
+            - name: POSTMARK_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: postmark_api_token
+            - name: RACK_ENV
+              value: production
+            - name: RAILS_ENV
+              value: production
+            - name: RAILS_LOG_TO_STDOUT
+              value: enabled
+            - name: RAILS_SERVE_STATIC_FILES
+              value: enabled
+            - name: REDIS_URL
+              value: redis://redis-master:6379
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: secret_key_base
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sentry_dsn
+            - name: TOKEN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: token_private_key
+            - name: INCREMENTAL_UPDATE
+              value: "1"


### PR DESCRIPTION
We now have tasks we need to run on a regular schedule — a job needs to go through and update the `status` field on Page objects in web-monitoring-db every so often. (They have to be updated on a schedule rather than based on a particular event because the results are based on a time window — the status could change just by time passing without new versions coming in.)

This adds Kubernetes `CronJob` configurations, which are basically containers that can be run on a cron-style schedule. At current, this runs them twice a day (every 12 hours). I already deployed this to staging to test, and it works great.

This is the finishing touch on edgi-govdata-archiving/web-monitoring#122.