### PR TITLE
Add configuration to deactivate old access keys

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/manually-managed/README.md
+++ b/manually-managed/README.md
@@ -43,6 +43,27 @@ To protect the production instance of the API from from abuse, we point the DNS 
     - It uses a `per-ip-rate-limit` rule to block IP addresses requesting over a certain rate.
 
 
+## IAM Access Key Expiration
+
+*This is not specific to Web Monitoring, but is a security concern for the AWS account it runs in.*
+
+We have some tools and scripts that use IAM access keys to get stuff done with AWS APIs (e.g. uploading to S3), but access keys unfortunately do not expire. That creates a big risk! (AWS has some nice solutions for OIDC and short-lived keys, but we have plenty of code that is not (yet?) compatible with that.)
+
+The CloudFormation template in [`expire-old-access-keys.yaml`](./expire-old-access-keys.yaml) creates a set of roles, policies, and configurations in AWS that will automatically expire old access keys and send warnings to an SNS topic about keys that are near expiration. To set it up:
+
+1. Ensure you have an SNS (Simple Notification Service) topic for admins to subscribe to and be notified about expiring access keys.
+
+    If you don’t already have one, you can create a topic in the AWS console at: https://us-west-2.console.aws.amazon.com/sns/v3/home. Name the topic anything you like, and then add the appropriate e-mail addresses or phone numbers for people who should be alerted about expiring keys (e.g. yourself). SNS topics are basically message queues that can be subscribed to via e-mail, SMS, or mobile push messages.
+
+    Note the ARN for your SNS topic.
+
+2. In [CloudFormation](https://us-west-2.console.aws.amazon.com/cloudformation/home)…
+    1. click the “create stack” button (a stack is a set of resources in AWS that are controlled together by a template). Then upload the [`expire-old-access-keys.yaml`](./expire-old-access-keys.yaml) file as the template to use.
+    2. On the next screen, give it an understandable name and fill in the parameters as appropriate: when you want keys to expire, when you want warnings about near-expiration keys, and the ARN for your SNS topic from step 1.
+    3. Follow the rest of the steps to instantiate the template.
+    4. You should be done and good to go!
+
+
 ## 📦 Deprecated Services
 
 ⚠️ These services used to be managed manually, but have either been shut down or moved to a different, automated approach. The documentation here is for historical reference.

--- a/manually-managed/expire-old-access-keys.yaml
+++ b/manually-managed/expire-old-access-keys.yaml
@@ -6,14 +6,23 @@
 #
 # Based on this AWS guide: https://aws.amazon.com/blogs/mt/managing-aged-access-keys-through-aws-config-remediations/
 # And the associated cloudformation template: https://raw.githubusercontent.com/aws-samples/aws-config-track-aged-access-keys/master/AccessKeyRotationChildAccounts.yaml
+#
+# TODO: Consider also expiring old or unused passwords!
+# - Config has a built-in `iam-user-unused-credentials-check` rule.
+# - SSM has a `AWSConfigRemediation-RevokeUnusedIAMUserCredentials` runbook.
+# - Use those in conjunction just like we currently do for basic key age with
+#   the `ACCESS_KEYS_ROTATED` Config rule and a custom SSM runbook.
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  Automatically warn about and expire old AWS IAM access keys.
-# Creates an Automation Document for distributing info on noncompliant Access Keys to an SNS distro. To accomplish this, creates an AWS Systems Manager Automation Document creates a role
-#   to allow AWS Config to execute SSM Automation Documents,
-#   execute the configservice list-discovered-resources API call,
-#   and publish to the SNS topic passed in
-# enables the AWS Config Rule access-keys-rotated hooks up the Automation Document created as the Config rule's automatic remediation action
+  Automatically warn about and expire old AWS IAM access keys. It requires you
+  have enabled AWS Config and are collecting information about IAM users in it,
+  and that you have an SNS topic to send expiration notices to.
+
+  This will create: 1) Rules in AWS Config for identifying keys near expiration
+  and after expiration, 2) AWS Systems Manager runbooks that "remediate" the
+  Config rules by either sending an SNS notification for each user with
+  near-expiration keys or by deactivating expired keys and sending an SNS
+  notification about that.
 
 Parameters:
   SNSTopic:
@@ -34,13 +43,13 @@ Parameters:
   maxAccessKeyAge:
     Type: String
     Default: '90'
-    Description: Maximum number of days without rotation. Default 90.
+    Description: Deactivate keys that are this many days old.
     MinLength: '1'
     ConstraintDescription: This parameter is required.
   warnAccessKeyAge:
     Type: String
     Default: '83'
-    Description: Send a warning after this many days without rotation.
+    Description: 'Send an "expiring soon" warning about keys this many days old.'
     MinLength: '1'
     ConstraintDescription: This parameter is required.
 
@@ -48,8 +57,7 @@ Resources:
   EdgiAccessKeyRotationRemediationRole:
     Type: AWS::IAM::Role
     Properties:
-      Description: Policies required for Config to execute SSM and SSM to execute
-        Config API call and publish to SNS
+      Description: Policies required for Config to execute SSM and SSM to update IAM, Config, and SNS.
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -92,15 +100,14 @@ Resources:
                   - 'iam:GetUser'
                   - 'iam:ListAccessKeys'
                   - 'iam:UpdateAccessKey'
-                  # - 'iam:PassRole'
                 Resource: '*'
       RoleName: EdgiAccessKeyRotationRemediationRole
 
-  EdgiAccessKeyRotationAutomationDoc:
+  EdgiAccessKeyAgeWarningRunbook:
     Type: AWS::SSM::Document
     Properties:
       Content:
-        description: Automation Document For resolving a User from a ResourceId
+        description: Send nice SNS warnings about IAM users whose keys expire soon.
         schemaVersion: '0.3'
         assumeRole: '{{ AutomationAssumeRole }}'
         parameters:
@@ -141,11 +148,11 @@ Resources:
           - resolveUsername.configUserName
       DocumentType: Automation
 
-  EdgiAccessKeyRevocationAutomationDoc:
+  EdgiAccessKeyAgeRevocationRunbook:
     Type: AWS::SSM::Document
     Properties:
       Content:
-        description: Automation Document For resolving a User from a ResourceId
+        description: "Deactivate an IAM user's expired access keys and send an SNS message about it."
         schemaVersion: '0.3'
         assumeRole: '{{ AutomationAssumeRole }}'
         parameters:
@@ -169,22 +176,120 @@ Resources:
               - Name: configUserName
                 Selector: $.resourceIdentifiers[0].resourceName
                 Type: String
-          # FIXME: Replace with script that deletes keys older than the given
-          # age, not just keys that haven't been *used* more recently.
-          # See source to fork: https://us-west-2.console.aws.amazon.com/systems-manager/documents/AWSConfigRemediation-RevokeUnusedIAMUserCredentials/content
           - name: revokeExpiredKeys
-            action: aws:executeAutomation
-            maxAttempts: 2
-            timeoutSeconds: 30
+            action: aws:executeScript
+            description: |
+              Deactivate access keys for an IAM user that were created more
+              `MaxCredentialAge` days ago.
+
+              This is based on AWS's official [`AWSConfigRemediation-RevokeUnusedIAMUserCredentials` runbook](https://us-west-2.console.aws.amazon.com/systems-manager/documents/AWSConfigRemediation-RevokeUnusedIAMUserCredentials/content),
+              but it looks at the age of the keys rather than when they were
+              last *used*. It also outputs some more detailed messaging.
+
+
+              ## Outputs
+
+              - `message`: String with information about each key's age and
+                  whether it was deactivated or left alone.
+              - `verification`: Map/dictionary with detailed information about
+                  verifications and API requests made. Useful for debugging in
+                  the AWS console, but you probably don't want to put it into
+                  an e-mail or text notification.
+            timeoutSeconds: 600
             isEnd: false
             nextStep: sendSuccessNotification
             onFailure: step:sendFailureNotification
             inputs:
-              DocumentName: AWSConfigRemediation-RevokeUnusedIAMUserCredentials
-              RuntimeParameters:
-                MaxCredentialUsageAge: !Ref maxAccessKeyAge
-                IAMResourceId: '{{ResourceId}}'
-                AutomationAssumeRole: '{{ AutomationAssumeRole }}'
+              Runtime: python3.11
+              Handler: main_handler
+              InputPayload:
+                IamResourceId: '{{ResourceId}}'
+                MaxCredentialAge: !Ref maxAccessKeyAge
+              Script: |
+                import boto3
+                from datetime import datetime, timedelta, timezone
+
+                iam_client = boto3.client("iam")
+                config_client = boto3.client("config")
+
+                responses = {}
+                responses["DeactivateUnusedKeysResponse"] = []
+
+                def list_access_keys(user_name):
+                  return iam_client.list_access_keys(UserName=user_name).get("AccessKeyMetadata")
+
+                def deactivate_key(user_name, access_key):
+                  responses["DeactivateUnusedKeysResponse"].append({
+                    "AccessKeyId": access_key,
+                    "Response": iam_client.update_access_key(
+                      UserName=user_name,
+                      AccessKeyId=access_key,
+                      Status="Inactive",
+                    ),
+                  })
+
+                def deactivate_old_keys(access_keys, max_age, user_name):
+                  results = []
+                  for key in access_keys:
+                    create_date = key.get("CreateDate")
+                    days_since_creation = (datetime.now(tz=timezone.utc) - create_date).days
+                    if days_since_creation >= max_age:
+                      deactivate_key(user_name, key.get("AccessKeyId"))
+                      results.append(f"Deactivated a {days_since_creation} day old key (created: {create_date} UTC).")
+                    else:
+                      results.append(f"Kept a {days_since_creation} day old key (created: {create_date} UTC).")
+
+                  return results
+
+                def verify_expired_keys_revoked(responses, user_name):
+                  if responses.get("DeactivateUnusedKeysResponse"):
+                    for key in responses.get("DeactivateUnusedKeysResponse"):
+                      key_data = next(filter(lambda x: x.get("AccessKeyId") == key.get("AccessKeyId"), list_access_keys(user_name)))
+                      if key_data.get("Status") != "Inactive":
+                        error_message = "VERIFICATION FAILED. ACCESS KEY {} NOT DEACTIVATED".format(key_data.get("AccessKeyId"))
+                        raise Exception(error_message)
+                  return {
+                      "output": "Verification of unused IAM User access keys is successful.",
+                      "http_responses": responses
+                  }
+
+                def get_user_name(resource_id):
+                  list_discovered_resources_response = config_client.list_discovered_resources(
+                      resourceType='AWS::IAM::User',
+                      resourceIds=[resource_id]
+                  )
+                  resource_name = list_discovered_resources_response.get("resourceIdentifiers")[0].get("resourceName")
+                  return resource_name
+
+                def main_handler(event, context):
+                  user_name = event.get("IamUserName")
+                  if not user_name:
+                    iam_resource_id = event.get("IamResourceId")
+                    if not iam_resource_id:
+                      raise ValueError(f"You must set either `IamUserName` or `IamResourceId` in the input payload.")
+                    user_name = get_user_name(iam_resource_id)
+
+                  max_credential_age = int(event.get("MaxCredentialAge"))
+                  if max_credential_age < 1:
+                    raise ValueError(f"MaxCredentialAge must be >= 1, but was '{max_credential_age}'.")
+
+                  access_keys = list_access_keys(user_name)
+                  results = deactivate_old_keys(access_keys, max_credential_age, user_name)
+                  verification = verify_expired_keys_revoked(responses, user_name)
+
+                  return {
+                    "message": "\n\n".join(results),
+                    "verification": verification,
+                  }
+            outputs:
+              # Useful reporting to admins about what happened.
+              - Name: message
+                Selector: $.Payload.message
+                Type: String
+              # Useful for debugging/troubleshooting in the AWS console.
+              - Name: verification
+                Selector: $.Payload.verification
+                Type: StringMap
           - name: sendFailureNotification
             action: aws:executeAwsApi
             timeoutSeconds: 30
@@ -198,7 +303,9 @@ Resources:
               Message: >
                   There was an error when revoking expired access keys for user
                   "{{resolveUsername.configUserName}}" in EDGI's AWS account!
-                  Please check AWS Systems Manager automations panel for
+
+
+                  Please check the AWS Systems Manager automations panel for
                   details:
 
                   This execution: https://{{global:REGION}}.console.aws.amazon.com/systems-manager/automation/execution/{{automation:EXECUTION_ID}}
@@ -216,20 +323,24 @@ Resources:
               Subject: EDGI AWS Access Keys Expired
               Message: >
                   EDGI AWS access keys for user
-                  "{{resolveUsername.configUserName}}" expired after being
-                  created ${maxAccessKeyAge} days ago!
+                  "{{resolveUsername.configUserName}}" expired!
+
+                  {{revokeExpiredKeys.message}}
+
+
+                  See this user's keys in AWS console:
+                  https://us-east-1.console.aws.amazon.com/iam/home#/users/details/{{resolveUsername.configUserName}}?section=security_credentials
         outputs:
           - resolveUsername.configUserName
+          - revokeExpiredKeys.message
       DocumentType: Automation
 
-  EdgiAWSConfigAccessKeyRotationRule:
+  EdgiAccessKeyAgeWarningConfigRule:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: warn-access-keys-expire-soon
-      Description: Checks whether the active access keys are rotated within the number
-        of days specified in maxAccessKeyAge. The rule is non-compliant if the
-        access keys have not been rotated for more than maxAccessKeyAge number
-        of days.
+      Description: Identify IAM users with access keys older than
+        `maxAccessKeyAge` days and use SSM to send an SNS notification.
       InputParameters:
         maxAccessKeyAge: !Ref warnAccessKeyAge
       Scope: {}
@@ -238,10 +349,10 @@ Resources:
         SourceIdentifier: ACCESS_KEYS_ROTATED
       MaximumExecutionFrequency: !Ref MaximumExecutionFrequency
 
-  EdgiAWSConfigAccessKeyRotationRuleRemediation:
+  EdgiAccessKeyAgeWarningConfigRuleRemediation:
     Type: AWS::Config::RemediationConfiguration
     Properties:
-      ConfigRuleName: !Ref EdgiAWSConfigAccessKeyRotationRule
+      ConfigRuleName: !Ref EdgiAccessKeyAgeWarningConfigRule
       Automatic: true
       MaximumAutomaticAttempts: 2
       RetryAttemptSeconds: 60
@@ -257,17 +368,16 @@ Resources:
         ResourceId:
           ResourceValue:
             Value: RESOURCE_ID
-      TargetId: !Ref EdgiAccessKeyRotationAutomationDoc
+      TargetId: !Ref EdgiAccessKeyAgeWarningRunbook
       TargetType: SSM_DOCUMENT
 
-  EdgiAWSConfigAccessKeyRevocationRule:
+  EdgiAccessKeyAgeRevocationConfigRule:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: expire-old-access-keys
-      Description: Checks whether the active access keys are rotated within the number
-        of days specified in maxAccessKeyAge. The rule is non-compliant if the
-        access keys have not been rotated for more than maxAccessKeyAge number
-        of days.
+      Description:  Identify IAM users with access keys older than
+        `maxAccessKeyAge` days and use SSM to deactivate those keys and send
+        an SNS notification about them.
       InputParameters:
         maxAccessKeyAge: !Ref maxAccessKeyAge
       Scope: {}
@@ -276,10 +386,10 @@ Resources:
         SourceIdentifier: ACCESS_KEYS_ROTATED
       MaximumExecutionFrequency: !Ref MaximumExecutionFrequency
 
-  EdgiAWSConfigAccessKeyRevocationRemediation:
+  EdgiAccessKeyAgeRevocationConfigRuleRemediation:
     Type: AWS::Config::RemediationConfiguration
     Properties:
-      ConfigRuleName: !Ref EdgiAWSConfigAccessKeyRevocationRule
+      ConfigRuleName: !Ref EdgiAccessKeyAgeRevocationConfigRule
       Automatic: true
       MaximumAutomaticAttempts: 2
       RetryAttemptSeconds: 60
@@ -295,7 +405,7 @@ Resources:
         ResourceId:
           ResourceValue:
             Value: RESOURCE_ID
-      TargetId: !Ref EdgiAccessKeyRevocationAutomationDoc
+      TargetId: !Ref EdgiAccessKeyAgeRevocationRunbook
       TargetType: SSM_DOCUMENT
 
 Metadata:
@@ -315,14 +425,24 @@ Conditions:
     - !Equals
       - ''
       - !Ref maxAccessKeyAge
+  warnAccessKeyAge: !Not
+    - !Equals
+      - ''
+      - !Ref warnAccessKeyAge
 
 Outputs:
   RoleCreated:
     Description: The IAM Role that was created
     Value: !Ref EdgiAccessKeyRotationRemediationRole
-  SSMDocumentCreated:
-    Description: The System Manager Automation Document that was created
-    Value: !Ref EdgiAccessKeyRotationAutomationDoc
-  AWSConfigRuleEnabled:
-    Description: The AWS Config Rule that was enabled
-    Value: !Ref EdgiAWSConfigAccessKeyRotationRule
+  WarningSsmDocumentCreated:
+    Description: The System Manager Automation Document to warn about old keys that was created
+    Value: !Ref EdgiAccessKeyAgeWarningRunbook
+  WarningConfigRuleEnabled:
+    Description: The AWS Config Rule for key warnings that was enabled
+    Value: !Ref EdgiAccessKeyAgeWarningConfigRule
+  RevocationSsmDocumentCreated:
+    Description: The System Manager Automation Document to revoke expired keys that was created
+    Value: !Ref EdgiAccessKeyAgeRevocationRunbook
+  RevocationConfigRuleEnabled:
+    Description: The AWS Config Rule for key revocation that was enabled
+    Value: !Ref EdgiAccessKeyAgeRevocationConfigRule

--- a/manually-managed/expire-old-access-keys.yaml
+++ b/manually-managed/expire-old-access-keys.yaml
@@ -57,7 +57,9 @@ Resources:
   EdgiAccessKeyRotationRemediationRole:
     Type: AWS::IAM::Role
     Properties:
-      Description: Policies required for Config to execute SSM and SSM to update IAM, Config, and SNS.
+      Description: >-
+        Grants AWS Config & SSM permission to revoke IAM access keys and send
+        notifications. (Managed in CloudFormation; do not edit manually.)
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -107,7 +109,9 @@ Resources:
     Type: AWS::SSM::Document
     Properties:
       Content:
-        description: Send nice SNS warnings about IAM users whose keys expire soon.
+        description: >-
+          Send nice SNS warnings about IAM users whose keys expire soon.
+          (Managed in CloudFormation; do not edit manually.)
         schemaVersion: '0.3'
         assumeRole: '{{ AutomationAssumeRole }}'
         parameters:
@@ -152,7 +156,9 @@ Resources:
     Type: AWS::SSM::Document
     Properties:
       Content:
-        description: "Deactivate an IAM user's expired access keys and send an SNS message about it."
+        description: >-
+          Deactivate an IAM user's expired access keys and send an SNS message
+          about it. (Managed in CloudFormation; do not edit manually.)
         schemaVersion: '0.3'
         assumeRole: '{{ AutomationAssumeRole }}'
         parameters:
@@ -339,8 +345,10 @@ Resources:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: warn-access-keys-expire-soon
-      Description: Identify IAM users with access keys older than
-        `maxAccessKeyAge` days and use SSM to send an SNS notification.
+      Description: >-
+        Identify IAM users with access keys older than `maxAccessKeyAge` days
+        and use SSM to send an SNS notification. (Managed in CloudFormation; do
+        not edit manually.)
       InputParameters:
         maxAccessKeyAge: !Ref warnAccessKeyAge
       Scope: {}
@@ -375,9 +383,10 @@ Resources:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: expire-old-access-keys
-      Description:  Identify IAM users with access keys older than
-        `maxAccessKeyAge` days and use SSM to deactivate those keys and send
-        an SNS notification about them.
+      Description: >-
+        Identify IAM users with access keys older than `maxAccessKeyAge` days
+        and use SSM to deactivate those keys and send an SNS notification about
+        them. (Managed in CloudFormation; do not edit manually.)
       InputParameters:
         maxAccessKeyAge: !Ref maxAccessKeyAge
       Scope: {}

--- a/manually-managed/expire-old-access-keys.yaml
+++ b/manually-managed/expire-old-access-keys.yaml
@@ -241,9 +241,9 @@ Resources:
                     days_since_creation = (datetime.now(tz=timezone.utc) - create_date).days
                     if days_since_creation >= max_age:
                       deactivate_key(user_name, key.get("AccessKeyId"))
-                      results.append(f"Deactivated a {days_since_creation} day old key (created: {create_date} UTC).")
+                      results.append(f"Deactivated a {days_since_creation:,} day old key (created: {create_date}).")
                     else:
-                      results.append(f"Kept a {days_since_creation} day old key (created: {create_date} UTC).")
+                      results.append(f"Kept a {days_since_creation:,} day old key (created: {create_date}).")
 
                   return results
 

--- a/manually-managed/expire-old-access-keys.yaml
+++ b/manually-managed/expire-old-access-keys.yaml
@@ -331,6 +331,7 @@ Resources:
                   EDGI AWS access keys for user
                   "{{resolveUsername.configUserName}}" expired!
 
+
                   {{revokeExpiredKeys.message}}
 
 

--- a/manually-managed/expire-old-access-keys.yaml
+++ b/manually-managed/expire-old-access-keys.yaml
@@ -1,0 +1,328 @@
+# EDGI AWS: Expire Old Access Keys
+#
+# This CloudFormation template creates IAM roles, Config rules, and SSM
+# documents/runbooks necessary to warn about access keys getting old, and then
+# later automatically expire them.
+#
+# Based on this AWS guide: https://aws.amazon.com/blogs/mt/managing-aged-access-keys-through-aws-config-remediations/
+# And the associated cloudformation template: https://raw.githubusercontent.com/aws-samples/aws-config-track-aged-access-keys/master/AccessKeyRotationChildAccounts.yaml
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Automatically warn about and expire old AWS IAM access keys.
+# Creates an Automation Document for distributing info on noncompliant Access Keys to an SNS distro. To accomplish this, creates an AWS Systems Manager Automation Document creates a role
+#   to allow AWS Config to execute SSM Automation Documents,
+#   execute the configservice list-discovered-resources API call,
+#   and publish to the SNS topic passed in
+# enables the AWS Config Rule access-keys-rotated hooks up the Automation Document created as the Config rule's automatic remediation action
+
+Parameters:
+  SNSTopic:
+    Type: String
+    Description: Send notifications for expiring access keys to this SNS Topic.
+  MaximumExecutionFrequency:
+    Type: String
+    Default: TwentyFour_Hours
+    Description: The frequency that you want AWS Config to run evaluations for the rule.
+    MinLength: '1'
+    ConstraintDescription: This parameter is required.
+    AllowedValues:
+      - One_Hour
+      - Three_Hours
+      - Six_Hours
+      - Twelve_Hours
+      - TwentyFour_Hours
+  maxAccessKeyAge:
+    Type: String
+    Default: '90'
+    Description: Maximum number of days without rotation. Default 90.
+    MinLength: '1'
+    ConstraintDescription: This parameter is required.
+  warnAccessKeyAge:
+    Type: String
+    Default: '83'
+    Description: Send a warning after this many days without rotation.
+    MinLength: '1'
+    ConstraintDescription: This parameter is required.
+
+Resources:
+  EdgiAccessKeyRotationRemediationRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Policies required for Config to execute SSM and SSM to execute
+        Config API call and publish to SNS
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ssm.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole
+      Policies:
+        - PolicyName: EdgiAccessKeyRotationConfigListResourcesPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: config:ListDiscoveredResources
+                Resource: '*'
+        - PolicyName: EdgiAccessKeyRotationPublishToSnsPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: sns:Publish
+                Resource: !Ref SNSTopic
+        - PolicyName: EdgiAccessKeyRotationRevocationPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            # Needed for revoking keys. See docs:
+            # https://docs.aws.amazon.com/systems-manager-automation-runbooks/latest/userguide/automation-aws-revoke-iam-user.html
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'ssm:StartAutomationExecution'
+                  - 'ssm:GetAutomationExecution'
+                  - 'config:ListDiscoveredResources'
+                  - 'iam:DeleteAccessKey'
+                  - 'iam:DeleteLoginProfile'
+                  - 'iam:GetAccessKeyLastUsed'
+                  - 'iam:GetLoginProfile'
+                  - 'iam:GetUser'
+                  - 'iam:ListAccessKeys'
+                  - 'iam:UpdateAccessKey'
+                  # - 'iam:PassRole'
+                Resource: '*'
+      RoleName: EdgiAccessKeyRotationRemediationRole
+
+  EdgiAccessKeyRotationAutomationDoc:
+    Type: AWS::SSM::Document
+    Properties:
+      Content:
+        description: Automation Document For resolving a User from a ResourceId
+        schemaVersion: '0.3'
+        assumeRole: '{{ AutomationAssumeRole }}'
+        parameters:
+          ResourceId:
+            type: String
+            description: (Required) The ResourceId of a User
+          AutomationAssumeRole:
+            type: String
+            description: (Optional) The ARN of the role that allows Automation to perform
+              the actions on your behalf.
+        mainSteps:
+          - name: resolveUsername
+            action: aws:executeAwsApi
+            inputs:
+              Service: config
+              Api: ListDiscoveredResources
+              resourceType: AWS::IAM::User
+              resourceIds:
+                - '{{ResourceId}}'
+            outputs:
+              - Name: configUserName
+                Selector: $.resourceIdentifiers[0].resourceName
+                Type: String
+          - name: sendNotification
+            action: aws:executeAwsApi
+            timeoutSeconds: 30
+            onFailure: Abort
+            inputs:
+              Service: sns
+              Api: Publish
+              TopicArn: !Ref SNSTopic
+              Subject: EDGI AWS Access Keys Expiring
+              Message: >
+                EDGI AWS user "{{resolveUsername.configUserName}}" has an
+                access key that will expire soon. Please rotate it and update
+                any external services using it.
+        outputs:
+          - resolveUsername.configUserName
+      DocumentType: Automation
+
+  EdgiAccessKeyRevocationAutomationDoc:
+    Type: AWS::SSM::Document
+    Properties:
+      Content:
+        description: Automation Document For resolving a User from a ResourceId
+        schemaVersion: '0.3'
+        assumeRole: '{{ AutomationAssumeRole }}'
+        parameters:
+          ResourceId:
+            type: String
+            description: (Required) The ResourceId of a User
+          AutomationAssumeRole:
+            type: String
+            description: (Optional) The ARN of the role that allows Automation to perform
+              the actions on your behalf.
+        mainSteps:
+          - name: resolveUsername
+            action: aws:executeAwsApi
+            inputs:
+              Service: config
+              Api: ListDiscoveredResources
+              resourceType: AWS::IAM::User
+              resourceIds:
+                - '{{ResourceId}}'
+            outputs:
+              - Name: configUserName
+                Selector: $.resourceIdentifiers[0].resourceName
+                Type: String
+          # FIXME: Replace with script that deletes keys older than the given
+          # age, not just keys that haven't been *used* more recently.
+          # See source to fork: https://us-west-2.console.aws.amazon.com/systems-manager/documents/AWSConfigRemediation-RevokeUnusedIAMUserCredentials/content
+          - name: revokeExpiredKeys
+            action: aws:executeAutomation
+            maxAttempts: 2
+            timeoutSeconds: 30
+            isEnd: false
+            nextStep: sendSuccessNotification
+            onFailure: step:sendFailureNotification
+            inputs:
+              DocumentName: AWSConfigRemediation-RevokeUnusedIAMUserCredentials
+              RuntimeParameters:
+                MaxCredentialUsageAge: !Ref maxAccessKeyAge
+                IAMResourceId: '{{ResourceId}}'
+                AutomationAssumeRole: '{{ AutomationAssumeRole }}'
+          - name: sendFailureNotification
+            action: aws:executeAwsApi
+            timeoutSeconds: 30
+            isEnd: true
+            onFailure: Abort
+            inputs:
+              Service: sns
+              Api: Publish
+              TopicArn: !Ref SNSTopic
+              Subject: EDGI AWS Access Keys Expired Error
+              Message: >
+                  There was an error when revoking expired access keys for user
+                  "{{resolveUsername.configUserName}}" in EDGI's AWS account!
+                  Please check AWS Systems Manager automations panel for
+                  details:
+
+                  This execution: https://{{global:REGION}}.console.aws.amazon.com/systems-manager/automation/execution/{{automation:EXECUTION_ID}}
+
+                  All executiosn: https://{{global:REGION}}.console.aws.amazon.com/systems-manager/automation/executions
+          - name: sendSuccessNotification
+            action: aws:executeAwsApi
+            timeoutSeconds: 30
+            isEnd: true
+            onFailure: Abort
+            inputs:
+              Service: sns
+              Api: Publish
+              TopicArn: !Ref SNSTopic
+              Subject: EDGI AWS Access Keys Expired
+              Message: >
+                  EDGI AWS access keys for user
+                  "{{resolveUsername.configUserName}}" expired after being
+                  created ${maxAccessKeyAge} days ago!
+        outputs:
+          - resolveUsername.configUserName
+      DocumentType: Automation
+
+  EdgiAWSConfigAccessKeyRotationRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: warn-access-keys-expire-soon
+      Description: Checks whether the active access keys are rotated within the number
+        of days specified in maxAccessKeyAge. The rule is non-compliant if the
+        access keys have not been rotated for more than maxAccessKeyAge number
+        of days.
+      InputParameters:
+        maxAccessKeyAge: !Ref warnAccessKeyAge
+      Scope: {}
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCESS_KEYS_ROTATED
+      MaximumExecutionFrequency: !Ref MaximumExecutionFrequency
+
+  EdgiAWSConfigAccessKeyRotationRuleRemediation:
+    Type: AWS::Config::RemediationConfiguration
+    Properties:
+      ConfigRuleName: !Ref EdgiAWSConfigAccessKeyRotationRule
+      Automatic: true
+      MaximumAutomaticAttempts: 2
+      RetryAttemptSeconds: 60
+      Parameters:
+        AutomationAssumeRole:
+          StaticValue:
+            Values:
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref AWS::AccountId
+                  - ':role/EdgiAccessKeyRotationRemediationRole'
+        ResourceId:
+          ResourceValue:
+            Value: RESOURCE_ID
+      TargetId: !Ref EdgiAccessKeyRotationAutomationDoc
+      TargetType: SSM_DOCUMENT
+
+  EdgiAWSConfigAccessKeyRevocationRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: expire-old-access-keys
+      Description: Checks whether the active access keys are rotated within the number
+        of days specified in maxAccessKeyAge. The rule is non-compliant if the
+        access keys have not been rotated for more than maxAccessKeyAge number
+        of days.
+      InputParameters:
+        maxAccessKeyAge: !Ref maxAccessKeyAge
+      Scope: {}
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCESS_KEYS_ROTATED
+      MaximumExecutionFrequency: !Ref MaximumExecutionFrequency
+
+  EdgiAWSConfigAccessKeyRevocationRemediation:
+    Type: AWS::Config::RemediationConfiguration
+    Properties:
+      ConfigRuleName: !Ref EdgiAWSConfigAccessKeyRevocationRule
+      Automatic: true
+      MaximumAutomaticAttempts: 2
+      RetryAttemptSeconds: 60
+      Parameters:
+        AutomationAssumeRole:
+          StaticValue:
+            Values:
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref AWS::AccountId
+                  - ':role/EdgiAccessKeyRotationRemediationRole'
+        ResourceId:
+          ResourceValue:
+            Value: RESOURCE_ID
+      TargetId: !Ref EdgiAccessKeyRevocationAutomationDoc
+      TargetType: SSM_DOCUMENT
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Required
+        Parameters:
+          - maxAccessKeyAge
+          - warnAccessKeyAge
+          - SNSTopic
+      - Label:
+          default: Optional
+        Parameters: []
+Conditions:
+  maxAccessKeyAge: !Not
+    - !Equals
+      - ''
+      - !Ref maxAccessKeyAge
+
+Outputs:
+  RoleCreated:
+    Description: The IAM Role that was created
+    Value: !Ref EdgiAccessKeyRotationRemediationRole
+  SSMDocumentCreated:
+    Description: The System Manager Automation Document that was created
+    Value: !Ref EdgiAccessKeyRotationAutomationDoc
+  AWSConfigRuleEnabled:
+    Description: The AWS Config Rule that was enabled
+    Value: !Ref EdgiAWSConfigAccessKeyRotationRule


### PR DESCRIPTION
We had a bit of a mess with old access keys recently, so this attempts to help prevent similar issues in the future by adding a CloudFormation template that will notify admins about and then deactivate old IAM user access keys.

It’s still a bit of a draft that needs some cleanup:

- [x] Deactivate old keys, not unused keys. This currently uses `AWSConfigRemediation-RevokeUnusedIAMUserCredentials`, which revokes keys that haven’t been *used* in a given time. I don’t think there’s a pre-built thing that does what we want (deactivate after a given time since creation), but it looks easy enough to hack up the script used in the unused credentials SSM document/runbook: https://us-west-2.console.aws.amazon.com/systems-manager/documents/AWSConfigRemediation-RevokeUnusedIAMUserCredentials/content
- [x] Clean up naming and descriptions and comments in the config.
- [x] Document how to set it up in [`manually-managed/README.md`](https://github.com/edgi-govdata-archiving/web-monitoring-ops/blob/main/manually-managed/README.md).

Obviously the more correct, long-term answer here is Identity Center and its short-term keys. However, I think those can only last hours at most, so we can’t just switch workflows using access keys today directly to them (we could if they could last, say, 30 days). I think this is also useful in general for scenarios where users make keys for themselves (unless we want to never grant that permission to people, which is maybe also worth considering in the long term…).